### PR TITLE
Auth

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -5,6 +5,7 @@ from pydantic import AnyHttpUrl, BaseSettings, PostgresDsn, validator
 
 class Settings(BaseSettings):
     PROJECT_NAME: str
+    SECRET_TOKEN: str
     BACKEND_CORS_ORIGINS: List[AnyHttpUrl] = []
 
     @validator("BACKEND_CORS_ORIGINS", pre=True)

--- a/app/main.py
+++ b/app/main.py
@@ -1,7 +1,8 @@
 # -*- coding: utf-8 -*-
-from fastapi import FastAPI
+from fastapi import FastAPI, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
 from sqlmodel import Session, select
+from starlette import status
 from starlette.responses import RedirectResponse
 
 from app.models import Speeches
@@ -31,7 +32,12 @@ def read_speeches():
 
 
 @app.post("/speeches/")
-def create_speeches(speech: Speeches):
+def create_speeches(speech: Speeches, token: str):
+    """The simplest auth option: token as a query param."""
+    if token != settings.SECRET_TOKEN:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED, detail="Not authenticated"
+        )
     with Session(engine) as session:
         session.add(speech)
         session.commit()


### PR DESCRIPTION
This PR is about handling security/auth
- resolved #7 (implemented auth via Bearer token - for both POST and GET requests)
- improved GET request by adding offset/limit query parameters

On the side note, auth request verifies tokens against a single secret token value; so it's not optimal generally, but still works for my use-case (only a scraper script should have access to API)