### PR TITLE
Tests update

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,7 +1,5 @@
 [run]
 omit = 
-    # Don't test database as I'm overriding engine & session
-    app/database.py
     # Not part of the application
     app/database_pre_start.py
     # Ignore empty files

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -2,7 +2,7 @@
 """This module contains BaseSettings config."""
 from typing import Any, Dict, List, Optional, Union
 
-from pydantic import BaseSettings, EmailStr, PostgresDsn, validator
+from pydantic import BaseSettings, EmailStr, PostgresDsn, validator, root_validator
 
 
 class Settings(BaseSettings):
@@ -27,19 +27,7 @@ class Settings(BaseSettings):
     POSTGRES_USER: str
     POSTGRES_PASSWORD: str
     POSTGRES_DB: str
-    DATABASE_URI: Optional[Union[str, PostgresDsn]] = None
-
-    @validator("DATABASE_URI", pre=True)
-    def assemble_db_connection(cls, v: Optional[str], values: Dict[str, Any]) -> Any:
-        if isinstance(v, str):
-            return v
-        return PostgresDsn.build(
-            scheme="postgresql",
-            user=values.get("POSTGRES_USER"),
-            password=values.get("POSTGRES_PASSWORD"),
-            host=values.get("POSTGRES_SERVER"),
-            path=f"/{values.get('POSTGRES_DB') or ''}",
-        )
+    DATABASE_URI: Optional[PostgresDsn] = None
 
     SMTP_TLS: bool = True
     SMTP_PORT: Optional[int] = None
@@ -57,15 +45,26 @@ class Settings(BaseSettings):
 
     EMAILS_ENABLED: bool = False
 
-    @validator("EMAILS_ENABLED", pre=True)
-    def get_emails_enabled(cls, v: bool, values: Dict[str, Any]) -> bool:
-        return bool(
+    @root_validator
+    def assemble_db_connection_and_get_emails_enabled(
+        cls, values: Dict[str, Any]
+    ) -> Any:
+        values["DATABASE_URI"] = PostgresDsn.build(
+            scheme="postgresql",
+            user=values.get("POSTGRES_USER"),
+            password=values.get("POSTGRES_PASSWORD"),
+            host=values.get("POSTGRES_SERVER"),
+            path=f"/{values.get('POSTGRES_DB') or ''}",
+        )
+        values["EMAILS_ENABLED"] = bool(
             values.get("SMTP_HOST")
             and values.get("SMTP_PORT")
             and values.get("EMAILS_FROM_EMAIL")
         )
+        return values
 
     class Config:
+        validate_assignment = True
         case_sensitive = True
         env_file = ".env"
 

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -2,7 +2,7 @@
 """This module contains BaseSettings config."""
 from typing import Any, Dict, List, Optional, Union
 
-from pydantic import BaseSettings, EmailStr, PostgresDsn, validator, root_validator
+from pydantic import BaseSettings, EmailStr, PostgresDsn, root_validator, validator
 
 
 class Settings(BaseSettings):

--- a/app/database_pre_start.py
+++ b/app/database_pre_start.py
@@ -7,6 +7,7 @@ from typing import Final
 from sqlmodel import Session, select
 from tenacity import after_log, before_log, retry, stop_after_attempt, wait_fixed
 
+from app.core.config import get_settings
 from app.database import get_engine
 
 logging.basicConfig(level=logging.INFO)
@@ -25,8 +26,8 @@ WAIT_SECONDS: Final = 1
 def init() -> None:
     """Tries to create session to check if database is awake."""
     try:
-        engine = get_engine()
-        with Session(engine) as session:
+        settings = get_settings()
+        with Session(get_engine(settings)) as session:
             session.exec(select(1))
     except Exception as generic_exception:
         logger.error(generic_exception)

--- a/app/models.py
+++ b/app/models.py
@@ -17,7 +17,7 @@ def custom_uuid() -> uuid.UUID:
     # https://github.com/tiangolo/sqlmodel/issues/25
     val = uuid.uuid4()
     while val.hex[0] == "0":
-        val = uuid.uuid4()
+        val = uuid.uuid4()  # pragma: no cover
     return val
 
 

--- a/app/tests/routers/test_notifications.py
+++ b/app/tests/routers/test_notifications.py
@@ -47,7 +47,6 @@ def test_send_email_emails_disabled_failure(monkeypatch, settings):
     # on it's own EMAILS_ENABLED = False doesn't work
     # as settings class runs root_validation that checks if SMTP options are set
     # and updates EMAILS_ENABLED field
-    updated_settings.EMAILS_ENABLED = False
     updated_settings.EMAILS_FROM_EMAIL = None
     with pytest.raises(AssertionError):
         send_email(email_to=EMAIL_TO, settings=updated_settings)

--- a/app/tests/test_database.py
+++ b/app/tests/test_database.py
@@ -1,0 +1,22 @@
+import pytest
+from app.database import get_engine, get_session
+
+
+def test_get_engine(settings):
+    """Successful engine creation."""
+    engine = get_engine(settings)
+    assert engine.name == "postgresql"
+
+    host, port = settings.POSTGRES_SERVER.split(":")
+    assert engine.url.host == host
+    assert engine.url.port == int(port)
+    assert engine.url.username == settings.POSTGRES_USER
+    assert engine.url.password == settings.POSTGRES_PASSWORD
+    assert engine.url.database == settings.POSTGRES_DB
+
+
+def test_get_session(settings):
+    """Successful connection."""
+    engine = get_engine(settings)
+    session = get_session(engine)
+    assert next(session).connection()


### PR DESCRIPTION
This PR slightly updates pre-start and testing components (#30) of the app:
- updates base settings configuration class to validate on assignment (so it validates the model on each field update)
- simplified conftest (added settings fixture adjusting for testing purposes) setup
- added tests related to database setup: `get_engine`, `get_session`
- fixes `app/database_pre_start.py` script error